### PR TITLE
remove requirement for gitLFS, and specify path for models

### DIFF
--- a/README.md
+++ b/README.md
@@ -6,6 +6,7 @@ This library implements the end-to-end facial synthesis model described in this 
 
 ## Downloading the models
 The models were hosted on git LFS. However the demand was so high that I reached the quota for free gitLFS storage. I have moved the models to GoogleDrive. Models can be found [here](https://drive.google.com/open?id=1pJdsnknLmMLvA8RQIAV3AQH8vU0FeK16).
+Place the model file(s) under sda/data/
 
 ## Installing
 

--- a/README.md
+++ b/README.md
@@ -4,9 +4,6 @@ This library implements the end-to-end facial synthesis model described in this 
 
 ![speech-driven-animation](example.gif)
 
-## Prerequisites
-The models provided are checked out using git LFS. You can install git LFS by following these [instructions](https://help.github.com/en/articles/installing-git-large-file-storage).
-
 ## Downloading the models
 The models were hosted on git LFS. However the demand was so high that I reached the quota for free gitLFS storage. I have moved the models to GoogleDrive. Models can be found [here](https://drive.google.com/open?id=1pJdsnknLmMLvA8RQIAV3AQH8vU0FeK16).
 


### PR DESCRIPTION
This change removes gitLFS as a listed prerequisite on the README, since it can no longer be used to fetched models, and specifies the local directory path to use for the model .dat files